### PR TITLE
講義30課題 受講生情報と受講生コース情報の削除処理（論理削除）の実装と軽微な修正

### DIFF
--- a/src/main/java/raisetech/StudentManagement/controller/StudentController.java
+++ b/src/main/java/raisetech/StudentManagement/controller/StudentController.java
@@ -77,6 +77,11 @@ public class StudentController {
       studentsCoursesList.add(new StudentCourse());
     }
 
+    /*
+     studentsCoursesList.getFirst()について：
+     このプロジェクトはJava21で開発しているので、ListにgetFirst()が実装されています
+     get(0)にするとIntelliJが警告をだすので、getFirst()を使っています
+    */
     service.registerStudentInfo(student, studentsCoursesList.getFirst());
 
     return "redirect:/studentList";

--- a/src/main/java/raisetech/StudentManagement/controller/StudentController.java
+++ b/src/main/java/raisetech/StudentManagement/controller/StudentController.java
@@ -9,8 +9,8 @@ import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import raisetech.StudentManagement.controller.converter.StudentConverter;
 import raisetech.StudentManagement.data.Student;
 import raisetech.StudentManagement.data.StudentCourse;
@@ -49,8 +49,8 @@ public class StudentController {
     return "registerStudent";
   }
 
-  @GetMapping("/updateStudent")
-  public String updateStudent(@RequestParam String id, Model model) {
+  @GetMapping("/updateStudent/{id}")
+  public String updateStudent(@PathVariable String id, Model model) {
     StudentDetail studentDetail = new StudentDetail();
     studentDetail.setStudent(service.searchStudent(id));
     studentDetail.setStudentsCourses(service.searchStudentCourseList(id));

--- a/src/main/java/raisetech/StudentManagement/repository/StudentRepository.java
+++ b/src/main/java/raisetech/StudentManagement/repository/StudentRepository.java
@@ -13,7 +13,7 @@ import raisetech.StudentManagement.data.StudentCourse;
 @Mapper
 public interface StudentRepository {
 
-  @Select("SELECT * FROM students")
+  @Select("SELECT * FROM students WHERE deleted = false")
   List<Student> searchStudents();
 
   @Select("SELECT * FROM students_courses")

--- a/src/main/java/raisetech/StudentManagement/repository/StudentRepository.java
+++ b/src/main/java/raisetech/StudentManagement/repository/StudentRepository.java
@@ -19,7 +19,7 @@ public interface StudentRepository {
   @Select("SELECT * FROM students_courses")
   List<StudentCourse> searchStudentsCourses();
 
-  @Select("SELECT * FROM students WHERE id = #{id}")
+  @Select("SELECT * FROM students WHERE id = #{id} AND deleted = false")
   Student searchStudent(@Param("id") String id);
 
   @Select("SELECT * FROM students_courses WHERE student_id = #{id}")

--- a/src/main/java/raisetech/StudentManagement/service/StudentService.java
+++ b/src/main/java/raisetech/StudentManagement/service/StudentService.java
@@ -51,6 +51,7 @@ public class StudentService {
     repository.registerStudentCourse(studentCourse);
   }
 
+  @Transactional
   public void updateStudentInfo(StudentDetail studentDetail) {
     repository.updateStudent(studentDetail.getStudent());
     for (StudentCourse studentCourse : studentDetail.getStudentsCourses()) {

--- a/src/main/resources/templates/studentList.html
+++ b/src/main/resources/templates/studentList.html
@@ -24,7 +24,7 @@
     <td rowspan="*{studentsCourses.size()}" data-th-text="${studentDetail.student.id}">1</td>
     <td rowspan="*{studentsCourses.size()}">
       <a data-th-text="${studentDetail.student.name}"
-         data-th-href="@{http://localhost:8080/updateStudent(id=${studentDetail.student.id})}">山田太郎</a>
+         data-th-href="@{http://localhost:8080/updateStudent/{id}(id=${studentDetail.student.id})}">山田太郎</a>
     </td>
     <td rowspan="*{studentsCourses.size()}" data-th-text="${studentDetail.student.furigana}">
       ヤマダタロウ

--- a/src/main/resources/templates/studentList.html
+++ b/src/main/resources/templates/studentList.html
@@ -24,7 +24,7 @@
     <td rowspan="*{studentsCourses.size()}" data-th-text="${studentDetail.student.id}">1</td>
     <td rowspan="*{studentsCourses.size()}">
       <a data-th-text="${studentDetail.student.name}"
-         data-th-href="@{http://localhost:8080/updateStudent/{id}(id=${studentDetail.student.id})}">山田太郎</a>
+         data-th-href="@{/updateStudent/{id}(id=${studentDetail.student.id})}">山田太郎</a>
     </td>
     <td rowspan="*{studentsCourses.size()}" data-th-text="${studentDetail.student.furigana}">
       ヤマダタロウ


### PR DESCRIPTION
## 概要
### 受講生情報と受講生コース情報の削除処理（論理削除）の実装
<p>更新画面にて受講生情報と受講生コース情報を論理削除できるようチェックボックスを配置しました。チェックボックスにチェックを入れて更新すると論理削除されます。論理削除をしたデータは受講生一覧に表示されませんがデータベースには残っています。</p>

### 軽微な修正
#### トランザクションに関する修正
<p>サービスにある更新処理でトランザクション管理をするよう修正しました</p>

#### getFirst()メソッドに関する修正
<p>コントローラにあるgetFirst()メソッドについて、get(0)ではなくgetFirst()を使う理由をコメントで説明しました。</p>

#### パスパラメータに関する修正
<p>受講背一覧ページから更新ページに遷移するときにクリックした受講生のIDを渡す必要があります。もともとクエリパラメータで実現していましたがパスパラメータによる方法に修正しました。</p>

#### 更新ページへのリンクに関する修正
<p>受講生一覧ページの受講生名にある更新ページへのリンクを、絶対パスから相対パスに修正しました。</p>

## 実装内容
### 受講生情報と受講生コース情報の削除処理（論理削除）の実装
- updateStudent.htmlに論理削除のチェックボックスを配置するコードを追加しました（前回までに実装済み）
- StudentRepositoryクラスのsearchStudentsメソッドに付与するSQL文に、論理削除がfalseであるレコードのみを取得するよう条件文を追記しました
- 同様に、StudentRepositoryクラスのsearchStudentメソッドのSQL文にも条件文を追記しました

### 軽微な修正
#### トランザクションに関する修正
- StudentServiceクラスのupdateStudentInfoメソッドにTransactionalアノテーションを付与しました

#### getFirst()メソッドに関する修正
- StudentControllerクラスのregisterStudentメソッドでservice.registerStudentInfoを呼び出している箇所にコメントを追記しました

#### パスパラメータに関する修正
- StudentConrollerクラスのupdateStudentメソッドの引数であるidに、PathVariableアノテーションを付与しました
- StudentList.htmlにある\<a\>タグのdata-th-href属性の末尾にパスパラメータ{id}を追記しました

#### 更新ページへのリンクに関する修正
- studentList.htmlにある\<a\>タグの属性data-th-hrefの値から`http://localhost:8080`を削除しました



## 動作確認
以下の手順で論理削除が正しく動作することを確認しました
1. 受講生一覧ページを開く
2. 削除したい受講生の名前をクリックする
3. 更新ページに飛ぶ
4. 論理削除のチェックボックスにチェックを入れる
5. 更新ボタンを押す
6. 受講生一覧ページに飛ぶ
7. 指定した受講生の情報が削除されている

＜参考動画＞

https://github.com/user-attachments/assets/a015e339-b0ba-4bd5-a69f-c75104e138ce


## 工夫したこと・学んだこと
- 講義の内容を参考にプログラムを改善しました
